### PR TITLE
Bugfix - set pool before base class init

### DIFF
--- a/pipe_tools/__init__.py
+++ b/pipe_tools/__init__.py
@@ -3,7 +3,7 @@ Tools for running dataflow jobs using bigquery
 """
 
 
-__version__ = '0.1.4'
+__version__ = '0.1.5a'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-tools'

--- a/pipe_tools/airflow/dataflow_operator.py
+++ b/pipe_tools/airflow/dataflow_operator.py
@@ -25,18 +25,15 @@ class DataFlowDirectRunnerOperator(DataFlowPythonOperator):
     @apply_defaults
     def __init__(self, *args, **kwargs):
 
+        dataflow_options = {}
+        dataflow_options.update (kwargs.get('dataflow_default_options') or {})
+        dataflow_options.update (kwargs.get('options') or {})
+
+        self._is_direct_runner = dataflow_options.get('runner') == 'DirectRunner'
+        default_pool = 'local_high_cpu' if self._is_direct_runner else 'dataflow'
+        kwargs['pool'] = kwargs.get('pool', default_pool)
+
         super(DataFlowDirectRunnerOperator, self).__init__(*args, **kwargs)
-
-        self.pool = self.pool or self._default_pool
-
-    @property
-    def _is_direct_runner(self):
-        runner = self.options.get('runner', self.dataflow_default_options.get('runner'))
-        return runner == 'DirectRunner'
-
-    @property
-    def _default_pool(self):
-        return 'local_high_cpu' if self._is_direct_runner else 'dataflow'
 
     def execute_direct_runner(self, context):
         bucket_helper = GoogleCloudBucketHelper(

--- a/pipe_tools/airflow/dataflow_operator.py
+++ b/pipe_tools/airflow/dataflow_operator.py
@@ -36,7 +36,7 @@ class DataFlowDirectRunnerOperator(DataFlowPythonOperator):
 
     @property
     def _default_pool(self):
-        return 'local_high_cpu' if self._is_direct_runner else 'dataflow'
+        return 'local-cpu' if self._is_direct_runner else 'dataflow'
 
     @property
     def pool(self):

--- a/pipe_tools/airflow/models.py
+++ b/pipe_tools/airflow/models.py
@@ -37,11 +37,15 @@ class DagFactory(object):
     def format_bigquery_table(self, project, dataset, table, date=None):
         return "{}:{}.{}".format(project, dataset, self.format_date_sharded_table(table, date))
 
-    def source_table_parts(self, date=None):
+    def source_tables(self):
         tables = self.config.get('source_tables') or self.config.get('source_table')
         assert tables
+        return tables.split(',')
 
-        for table in tables.split(','):
+    def source_table_parts(self, date=None):
+        tables = self.source_tables()
+
+        for table in tables:
             yield dict(
                 project=self.config['project_id'],
                 dataset=self.config['source_dataset'],

--- a/tests/test_airflow.py
+++ b/tests/test_airflow.py
@@ -98,7 +98,7 @@ class TestAirflow:
         (None, 'dataflow'),
         ({}, 'dataflow'),
         ({'runner':'DataflowRunner'}, 'dataflow'),
-        ({'runner': 'DirectRunner'}, 'local_high_cpu'),
+        ({'runner': 'DirectRunner'}, 'local-cpu'),
     ])
     def test_DataFlowDirectRunnerOperator_pool(self, options, expected, dag):
         op = DataFlowDirectRunnerOperator(


### PR DESCRIPTION
Looks like the real problem here was that the pool name was not defined in the running airflow instance.  This causes the scheduler to cough up blood and die