### PR TITLE
New airflow defaults

### DIFF
--- a/pipe_tools/__init__.py
+++ b/pipe_tools/__init__.py
@@ -3,7 +3,7 @@ Tools for running dataflow jobs using bigquery
 """
 
 
-__version__ = '0.1.5a'
+__version__ = '0.1.5b'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-tools'

--- a/pipe_tools/airflow/config.py
+++ b/pipe_tools/airflow/config.py
@@ -15,6 +15,10 @@ def load_config (variable_name):
     config['last_day_of_month'] = '{{ (execution_date.replace(day=1) + macros.dateutil.relativedelta.relativedelta(months=1, days=-1)).strftime("%Y-%m-%d") }}'
     config['first_day_of_month_nodash'] = '{{ execution_date.replace(day=1).strftime("%Y%m%d") }}'
     config['last_day_of_month_nodash'] = '{{ (execution_date.replace(day=1) + macros.dateutil.relativedelta.relativedelta(months=1, days=-1)).strftime("%Y%m%d") }}'
+    config['first_day_of_year'] = '{{ execution_date.replace(day=1, month=1).strftime("%Y-%m-%d") }}'
+    config['last_day_of_year'] = '{{ (execution_date.replace(day=1, month=1) + macros.dateutil.relativedelta.relativedelta(years=1, days=-1)).strftime("%Y-%m-%d") }}'
+    config['first_day_of_year_nodash'] = '{{ execution_date.replace(day=1, month=1).strftime("%Y%m%d") }}'
+    config['last_day_of_year_nodash'] = '{{ (execution_date.replace(day=1, month=1) + macros.dateutil.relativedelta.relativedelta(years=1, days=-1)).strftime("%Y%m%d") }}'
     return config
 
 

--- a/pipe_tools/airflow/models.py
+++ b/pipe_tools/airflow/models.py
@@ -74,7 +74,8 @@ class DagFactory(object):
             poke_interval=10,  # check every 10 seconds for a minute
             timeout=60,
             retries=24 * 7,  # retry once per hour for a week
-            retry_delay=timedelta(minutes=60)
+            retry_delay=timedelta(minutes=60),
+            retry_exponential_backoff=False
         )
 
     def source_table_sensors(self, dag):

--- a/pipe_tools/airflow/models.py
+++ b/pipe_tools/airflow/models.py
@@ -20,6 +20,8 @@ class DagFactory(object):
             return '{{ ds_nodash }}'
         elif self.schedule_interval == '@monthly':
             return '{last_day_of_month_nodash}'.format(**self.config)
+        elif self.schedule_interval == '@yearly':
+            return '{last_day_of_year_nodash}'.format(**self.config)
         else:
             raise ValueError('Unsupported schedule interval {}'.format(self.schedule_interval))
 
@@ -28,6 +30,8 @@ class DagFactory(object):
             return '{{ ds }}', '{{ ds }}'
         elif self.schedule_interval == '@monthly':
             return self.config['first_day_of_month'], self.config['last_day_of_month']
+        elif self.schedule_interval == '@yearly':
+            return self.config['first_day_of_year'], self.config['last_day_of_year']
         else:
             raise ValueError('Unsupported schedule interval {}'.format(self.schedule_interval))
 


### PR DESCRIPTION
Closes #41 default task config uses exponential backoff for retry interval
Closes #42 Support `@yearly`schedule interval in dag factory
  