### PR TITLE
Release v0.1.6 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.1.6 - (2018-05-13)
+--------------------
+
+* [#40](https://github.com/GlobalFishingWatch/pipe-tools/pull/40)
+  Change parallelization in xdaterange from 8 to 4
+* [#44](https://github.com/GlobalFishingWatch/pipe-tools/pull/44)
+  Airflow dag factory supports @yearly schedule interval and exponential backoff on retry
+
 
 0.1.5 - (2018-03-25)
 --------------------

--- a/pipe_tools/__init__.py
+++ b/pipe_tools/__init__.py
@@ -3,7 +3,7 @@ Tools for running dataflow jobs using bigquery
 """
 
 
-__version__ = '0.1.5b'
+__version__ = '0.1.6'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-tools'


### PR DESCRIPTION
Closes #43 

### Changes

#40 Change parallelization in xdaterange from 8 to 4
#44 Airflow dag factory supports `@yearly` schedule interval and exponential backoff on retry