### PR TITLE
828 Centralize events pipeline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Changelog
 0.2.0 - (2018-09-13)
 --------------------
 
-* [#47](https://github.com/GlobalFishingWatch/pipe-tools/pull/46)
+* [#47](https://github.com/GlobalFishingWatch/pipe-tools/pull/47)
   * Fixes `DagFactory` config initialization order so that the `extra_config` is taken into account before `default_args` processing.
   * Adds a new `base_config` argument to `DagFactory` initialization that is used as the base configuration. The configuration that's loaded from the airflow variables is merged into this base config, and then the `extra_config` is merged afterwards.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,72 +1,72 @@
 Changelog
 =========
 
+0.2.0 - (2018-09-13)
+--------------------
+
+* [#47](https://github.com/GlobalFishingWatch/pipe-tools/pull/46)
+  * Fixes `DagFactory` config initialization order so that the `extra_config` is taken into account before `default_args` processing.
+  * Adds a new `base_config` argument to `DagFactory` initialization that is used as the base configuration. The configuration that's loaded from the airflow variables is merged into this base config, and then the `extra_config` is merged afterwards.
+
 0.1.7 - (2018-08-27)
 --------------------
 
 * [#46](https://github.com/GlobalFishingWatch/pipe-tools/pull/46)
-  Pin version of airflow to 1.9.0
-
+  * Pin version of airflow to 1.9.0
 
 0.1.6 - (2018-05-13)
 --------------------
 
 * [#40](https://github.com/GlobalFishingWatch/pipe-tools/pull/40)
-  Change parallelization in xdaterange from 8 to 4
+  * Change parallelization in xdaterange from 8 to 4
 * [#44](https://github.com/GlobalFishingWatch/pipe-tools/pull/44)
-  Airflow dag factory supports @yearly schedule interval and exponential backoff on retry
-
+  * Airflow dag factory supports @yearly schedule interval and exponential backoff on retry
 
 0.1.5 - (2018-03-25)
 --------------------
 
 * [#34](https://github.com/GlobalFishingWatch/pipe-tools/pull/34)
-  Automatically set pool based on the runner in DataFlowDirectRunnerOperator
+  * Automatically set pool based on the runner in DataFlowDirectRunnerOperator
 * [#36](https://github.com/GlobalFishingWatch/pipe-tools/pull/36)
-  Utility bash scripts - xdaterange
+  * Utility bash scripts - xdaterange
 * [#37](https://github.com/GlobalFishingWatch/pipe-tools/pull/37)
-  DagFactory
-  
-  
+  * DagFactory
+
 0.1.4 - (2018-03-11)
 --------------------
 
 * [#27](https://github.com/GlobalFishingWatch/pipe-tools/pull/27)
-  GCP source and sink classes for generic GCP read/write
+  * GCP source and sink classes for generic GCP read/write
 * [#31](https://github.com/GlobalFishingWatch/pipe-tools/pull/31)
-  Common tools for airflow dags
- 
- 
+  * Common tools for airflow dags
+
 0.1.3 - (2018-01-01)
 --------------------
 
 * ['#23'](https://github.com/GlobalFishingWatch/pipe-tools/pull/23)
-  bugfixes for timestamp handling edgecases
+  * bugfixes for timestamp handling edgecases
 
 0.1.2 - (2017-12-15)
 --------------------
 
 * ['#16'](https://github.com/GlobalFishingWatch/pipe-tools/pull/16)
-  Update cli options handling an help display to be compatible with PipelineOptions model
-  Standardized uuid generator with GFW namespace
+  * Update cli options handling an help display to be compatible with PipelineOptions model
+  * Standardized uuid generator with GFW namespace
 
 * ['#18'](https://github.com/GlobalFishingWatch/pipe-tools/pull/18)
-  bug fix for writing partitioned files with 0 rows
-  
+  * bug fix for writing partitioned files with 0 rows
+
 0.1.1 - (2017-11-24)
 --------------------
 
 * ['#5'](https://github.com/GlobalFishingWatch/pipe-tools/pull/5)
-  New tool for detecting schema of bigquery tables
+  * New tool for detecting schema of bigquery tables
 * ['#7'](https://github.com/GlobalFishingWatch/pipe-tools/pull/7)
-  Cookbook exampledemonstrates how to use ValueProviders to deploy a 
-  pipeline as a template in Dataflow, and how to launch a templated 
-  pipeline with Cloud Functions
+  * Cookbook exampledemonstrates how to use ValueProviders to deploy a pipeline as a template in Dataflow, and how to launch a templated pipeline with Cloud Functions
 * ['#9'](https://github.com/GlobalFishingWatch/pipe-tools/pull/9)
-  Refactor date partitioned writer to provide more generic
-  key partitioned write for any arbitrary key values
-  
-  
+  * Refactor date partitioned writer to provide more generic key partitioned write for any arbitrary key values
+
+
 0.1.0 - (2017-10-22)
 --------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:2.7
+
+RUN mkdir -p /opt/project
+WORKDIR /opt/project
+
+COPY . /opt/project
+RUN pip install -e .

--- a/README.md
+++ b/README.md
@@ -1,19 +1,36 @@
 [![Build Status](https://travis-ci.org/GlobalFishingWatch/pipe-tools.svg?branch=master)](https://travis-ci.org/GlobalFishingWatch/pipe-tools)
 
 # pipe-tools
-Dataflow pipeline tools and utilities
 
-## Install
-```console 
-virtualenv venv
-source venv/bin/activate
-pip install --upgrade pip
-pip install .
+[Airflow](https://airflow.apache.org/) / [Dataflow](https://cloud.google.com/dataflow/) pipeline tools and utilities.
+
+## Installation
+
+TODO: Document the installation process
+
+## Usage
+
+TODO: Document the utilities that we provide and how to use them
+
+## Development
+
+To setup your development environment you have 2 options. The recommended way is through [docker](https://www.docker.com/), although you can also use a local [python](https://www.python.org/) installation if you prefer so.
+
+### Docker
+
+If you have [docker](https://www.docker.com/) and [docker compose](https://docs.docker.com/compose/) on your machine, we provide an image which contains everything that's needed. Just run the following command to run the tests:
+
+```console
+sudo docker-compose run test
 ```
 
-## Development and Testing
+### Local python
+
+You need to have [python](https://www.python.org/) 2.7. [Virtualenv](https://virtualenv.pypa.io/en/stable/) is recommended as well. Just run the following commands to run the tests, and you are ready to start hacking around:
 
 ```cconsole
+virtualenv venv
+source venv/bin/activate
 pip install -e .
 py.test tests
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  test:
+    image: gfw/pipe-tools
+    build: .
+    command: py.test tests
+    volumes:
+      - "./:/opt/project"

--- a/pipe_tools/__init__.py
+++ b/pipe_tools/__init__.py
@@ -3,7 +3,7 @@ Tools for running dataflow jobs using bigquery
 """
 
 
-__version__ = '0.1.7'
+__version__ = '0.2.0'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-tools'

--- a/pipe_tools/airflow/models.py
+++ b/pipe_tools/airflow/models.py
@@ -5,13 +5,16 @@ from airflow.contrib.sensors.bigquery_sensor import BigQueryTableSensor
 
 
 class DagFactory(object):
-    def __init__(self, pipeline, schedule_interval='@daily', extra_default_args=None, extra_config=None):
+    def __init__(self, pipeline, schedule_interval='@daily', extra_default_args={}, extra_config={}, base_config={}):
         self.pipeline = pipeline
-        self.config = config_tools.load_config(pipeline)
-        self.default_args = config_tools.default_args(self.config)
 
-        self.default_args.update(extra_default_args or {})
-        self.config.update(extra_config or {})
+        loaded_config = config_tools.load_config(pipeline)
+        self.config = base_config.copy()
+        self.config.update(loaded_config)
+        self.config.update(extra_config)
+
+        self.default_args = config_tools.default_args(self.config)
+        self.default_args.update(extra_default_args)
 
         self.schedule_interval = schedule_interval
 


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/GFW-Tasks/issues/828

The main change this PR introduces is a new `DagFactory` config initialization procedure:

* The entire configuration is processed first before the rest of the of the initialization is done. This allows the `extra_config` to be processed before `default_args` are loaded.
* A new `base_config` parameter is added. The idea here is that you can provide defaults through `base_config`, which can then be overriden by the config from airflow and then overriden again by the `extra_config`.

There are a couple of extra things I sneaked in, mostly dev stuff:

* Adds docker infrastructure to run the project.
* Adds a bit of documentation on the development workflow and some placeholders for documenting the actual utilities we provide. It'd be nice to do some work there, eventually, now that this is semi-stable.