### PR TITLE
Pin Airflow version to 1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ cache:
 python:
 - 2.7
 
+env:
+- SLUGIFY_USES_TEXT_UNIDECODE=yes
+
 install:
 - pip install -e .
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changelog
 
 * [#50](https://github.com/GlobalFishingWatch/pipe-tools/pull/50)
   * Pin Airflow version to 1.10.0
+  * Pin Airflow version to 1.10.1
   * NOTE: This changes where not tested on existing pipelines with 1.9.0
 
 0.2.4 - (2018-11-15)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.2.5 - (2018-11-21)
+--------------------
+
+* [#49](https://github.com/GlobalFishingWatch/pipe-tools/pull/49)
+  * Pin Airflow version to 1.10.0
+
 0.2.4 - (2018-11-15)
 --------------------
 
@@ -12,7 +18,6 @@ Changelog
 * Includes parse_gcs_url method from Airflow version 1.10.0, needed in case the schema reads from GCS. Not contemplated in Airflow 1.9
 * Creates class `BigQueryHelperCursor` wrapper to create_empty_tables from service cursor. Not contemplated in Airflow 1.9
 * Creates `AirflowException` to return an error in case the creation of tables fails.
-
 
 0.2.1 - 
 --------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,12 @@
 Changelog
 =========
 
-0.2.5 - (2018-11-21)
+1.0.0 - (2018-11-21)
 --------------------
 
 * [#50](https://github.com/GlobalFishingWatch/pipe-tools/pull/50)
   * Pin Airflow version to 1.10.0
+  * NOTE: This changes where not tested on existing pipelines with 1.9.0
 
 0.2.4 - (2018-11-15)
 --------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,6 @@ Changelog
 --------------------
 
 * [#50](https://github.com/GlobalFishingWatch/pipe-tools/pull/50)
-  * Pin Airflow version to 1.10.0
   * Pin Airflow version to 1.10.1
   * NOTE: This changes where not tested on existing pipelines with 1.9.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Changelog
 0.2.5 - (2018-11-21)
 --------------------
 
-* [#49](https://github.com/GlobalFishingWatch/pipe-tools/pull/49)
+* [#50](https://github.com/GlobalFishingWatch/pipe-tools/pull/50)
   * Pin Airflow version to 1.10.0
 
 0.2.4 - (2018-11-15)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:2.7
 
+# Airflow GPL dependency
+ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
+
 RUN mkdir -p /opt/project
 WORKDIR /opt/project
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,10 @@ services:
     command: py.test tests
     volumes:
       - "./:/opt/project"
+
+  bash:
+    image: gfw/pipe-tools
+    build: .
+    command: bash
+    volumes:
+      - "./:/opt/project"

--- a/pipe_tools/__init__.py
+++ b/pipe_tools/__init__.py
@@ -3,7 +3,7 @@ Tools for running the GFW pipeline.
 """
 
 
-__version__ = '0.2.1'
+__version__ = '1.0.0'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-tools'

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ DEPENDENCIES = [
     "python-dateutil",
     "newlinejson",
     "apache-airflow==1.10.0",
+    "cryptography",
+    "kubernetes",
     "pandas-gbq",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ DEPENDENCIES = [
     "udatetime",
     "python-dateutil",
     "newlinejson",
-    "apache-airflow==1.10.0",
+    "apache-airflow==1.10.1",
     "cryptography",
     "kubernetes",
     "pandas-gbq",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ DEPENDENCIES = [
 ]
 
 AIRFLOW_DEPENDENCIES = [
-    "google-api-python-client"
+    "google-api-python-client",
+    "snakebite"
 ]
 
 # Frozen dependencies for the google cloud dataflow dependency

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ DEPENDENCIES = [
     "udatetime",
     "python-dateutil",
     "newlinejson",
-    "apache-airflow==1.9.0",
+    "apache-airflow==1.10.0",
     "pandas-gbq",
 ]
 

--- a/tests/test_airflow.py
+++ b/tests/test_airflow.py
@@ -1,13 +1,14 @@
 import pytest
-from datetime import datetime
 from datetime import timedelta
 import os
 
 from airflow import configuration, DAG
+from airflow.utils.db import initdb
 from airflow.utils.state import State
+from airflow.utils.timezone import datetime
+from airflow.utils.timezone import utcnow
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator
-from airflow.utils.db import initdb
 from airflow.models import Variable
 from pipe_tools.airflow.operators.python_operator import ExecutionDateBranchOperator
 from pipe_tools.airflow.dataflow_operator import DataFlowDirectRunnerOperator
@@ -95,7 +96,7 @@ class TestAirflow:
 
         dr = dag.create_dagrun(
             run_id="manual__",
-            start_date=datetime.utcnow(),
+            start_date=utcnow(),
             execution_date=DEFAULT_DATE,
             state=State.RUNNING
         )


### PR DESCRIPTION
* Ignore the GPL dependency in Dockerfile
* Install `cryptography` package to fix issue when model.py uses
`https://github.com/apache/incubator-airflow/blob/1.10.0/airflow/models.py#L147`
* Install `kubernetes` package to run the example_dags
* Uses `airflow.utils.timezone` instead of `datetime`` as `datetime`
* Uses `airflow.utils.timezone.utcnow()` instead `datetime.utcnow()`
* Updates CHANGES.md with the correct PR number
* Updates the travis config to set the `SLUGIFY_USES_TEXT_UNIDECODE` variable

Related with https://github.com/GlobalFishingWatch/GFW-Tasks/issues/884