### PR TITLE
Bigquery operator create if not exist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+0.2.4 - (2018-11-15)
+--------------------
+
+* [51](https://github.com/GlobalFishingWatch/pipe-tools/pull/51)
+* Returns generator object for `daterange` method.
+* Parse the string date to a Airflow format accepted using `AIRFLOW_DATE`.
+* Iterates and creates empty table for needed dates.
+* Logs all the process to verify each step
+* Includes parse_gcs_url method from Airflow version 1.10.0, needed in case the schema reads from GCS. Not contemplated in Airflow 1.9
+* Creates class `BigQueryHelperCursor` wrapper to create_empty_tables from service cursor. Not contemplated in Airflow 1.9
+* Creates `AirflowException` to return an error in case the creation of tables fails.
+
+
 0.2.1 - 
 --------------------
 

--- a/pipe_tools/airflow/dataflow_operator.py
+++ b/pipe_tools/airflow/dataflow_operator.py
@@ -8,6 +8,7 @@ from airflow.utils.decorators import apply_defaults
 
 
 class DataFlowDirectRunnerHook(DataFlowHook):
+
     def _start_dataflow(self, task_id, variables, dataflow, name, command_prefix):
         cmd = command_prefix + self._build_cmd(task_id, variables, dataflow)
         _Dataflow(cmd).wait_for_done()

--- a/pipe_tools/timestamp.py
+++ b/pipe_tools/timestamp.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import udatetime
 import pytz
 
@@ -17,6 +17,8 @@ BEAM_BQ_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S.%f UTC"  # this is the format bigq
 # This is a much better string format for datetimes that is supported by udatetime
 # Note that %z is not supported in pythng 2.7 for udatetime.strptime()
 RFC3339_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
+
+AIRFLOW_DATE = "%Y-%m-%d"
 
 DATE_FORMAT = "%Y-%m-%d"
 
@@ -136,6 +138,25 @@ def rfc3339strFromTimestamp(ts):
 
 def timestampFromRfc3339str(s):
     return timestampFromUdatetime(udatetime.from_string(s))
+
+def str2date(s):
+    """
+    :param s date in string expresed with the format AIRFLOW_DATE
+    :type s string
+    :return datetime representing the string s.
+    """
+    return datetime.strptime(s, AIRFLOW_DATE)
+
+def daterange(start_date, end_date):
+    """
+    :param start_date start date
+    :type start_date datetime
+    :param end_date end date
+    :type end_date datetime
+    :return generator dates between start_date and end_date
+    """
+    for n in range(int ((end_date - start_date).days)+1):
+        yield start_date + timedelta(n)
 
 @typehints.with_input_types(JSONDict)
 @typehints.with_output_types(JSONDict)


### PR DESCRIPTION
* returns generator object for `daterange` method.
* parse the string date to a Airflow format accepted using `AIRFLOW_DATE`.
* iterates and creates empty table for needed dates.
* logs all the process to verify each step
* includes parse_gcs_url method from Airflow version 1.10.0, needed in case the schema reads from GCS. Not contemplated in Airflow 1.9
* creates class `BigQueryHelperCursor` wrapper to create_empty_tables from service cursor. Not contemplated in Airflow 1.9
* creates `AirflowException` to return an error in case the creation of tables fails.

Related to https://github.com/GlobalFishingWatch/GFW-Tasks/issues/825