### PR TITLE
Release 3.0.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,14 +8,23 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
-### ADDED
 
 ## 3.0.0 - (2019-03-27)
 
+
+### CHANGED
+
+**BREAKING CHANGE, Only compatible with 3.x pipelines**
+
   * [#59] https://github.com/GlobalFishingWatch/pipe-tools/pull/59
-    * BREAKING CHANGE -- see notes in PR referenced above.
     * Update to work with Apache Beam 2.11.
     * Partially automate creation of requirements list for setup.
+
+### ADDED
+
+  * [#59] https://github.com/GlobalFishingWatch/pipe-tools/pull/59
+    * Beam requirements can now be imported from `pipe_tools.beam.requirements` 
+
 
 ## 2.0.0 - (2019-03-08)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,13 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ### ADDED
 
+## 3.0.0 - (2019-03-27)
+
+  * [#59] https://github.com/GlobalFishingWatch/pipe-tools/pull/59
+    * BREAKING CHANGE -- see notes in PR referenced above.
+    * Update to work with Apache Beam 2.11.
+    * Partially automate creation of requirements list for setup.
+
 ## 2.0.0 - (2019-03-08)
 
   * [#968](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/968)

--- a/pipe_tools/__init__.py
+++ b/pipe_tools/__init__.py
@@ -3,7 +3,7 @@ Tools for running the GFW pipeline.
 """
 
 
-__version__ = '2.0.0'
+__version__ = '3.0.0'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-tools'

--- a/pipe_tools/beam/requirements.py
+++ b/pipe_tools/beam/requirements.py
@@ -33,39 +33,4 @@ pyyaml  >=3.12,<4.0.0
 typing  >=3.6.0,<3.7.0; python_version < "3.5.0"
 """
 
-py2_reqs = set([
-    'python_version<"3.0"',
-
-    ])
-
-py3_reqs = set([
-    'python_version>="3.0"',
-    'python_version>="3.0"orplatform_system!="windows"'
-    ])
-
-def parse_beam_requirements(text):
-    py3 = (sys.version_info.major == 3)
-    requirements = ["apache_beam==" + beam_version]
-    for line in text.split('\n'):
-        line = line.strip()
-        if not line:
-            continue
-        if ';' in line:
-            line, req = line.split(';', 1)
-            req = req.lower().replace(' ', '')
-            if req in py3_reqs:
-                if not py3:
-                    continue
-            elif req in py2_reqs:
-                if py3:
-                    continue
-            elif req == 'python_version<"3.5.0"':
-                if sys.version_info.major == 3 and sys.version_info.minor >= 5:
-                    # Hack for typing module
-                    continue
-            else:
-                logging.warn('ignoring spec: {}'.format(req))
-        requirements.append('{}'.format(line.replace(' ','')))
-    return requirements
-
-requirements = parse_beam_requirements(beam_requirement_text)
+requirements = ["apache_beam==" + beam_version] + beam_requirement_text.split('\n')

--- a/pipe_tools/beam/requirements.py
+++ b/pipe_tools/beam/requirements.py
@@ -1,7 +1,21 @@
-import logging
-import sys
+"""Requirements for Apache Beam
 
-# From https://beam.apache.org/documentation/sdks/python-dependencies/
+Module for holding the dependencies for the currently
+used Apache Beam version. 
+
+To update the dependencies:
+
+1. Go to https://beam.apache.org/documentation/sdks/python-dependencies/
+   and select the version of bean you want to use.
+
+2. Copy the table and replace the contents of `beam_requirement_text` below
+   with it.
+
+3. Update `beam_version` to version you selected in 1.
+
+
+"""
+
 beam_version = "2.11.0"
 
 beam_requirement_text = """

--- a/pipe_tools/beam/requirements.py
+++ b/pipe_tools/beam/requirements.py
@@ -2,6 +2,8 @@ import logging
 import sys
 
 # From https://beam.apache.org/documentation/sdks/python-dependencies/
+beam_version = "2.11.0"
+
 beam_requirement_text = """
 avro-python3    >=1.8.1,<2.0.0; python_version >= "3.0"
 avro    >=1.8.1,<2.0.0; python_version < "3.0"
@@ -43,7 +45,7 @@ py3_reqs = set([
 
 def parse_beam_requirements(text):
     py3 = (sys.version_info.major == 3)
-    requirements = []
+    requirements = ["apache_beam==" + beam_version]
     for line in text.split('\n'):
         line = line.strip()
         if not line:

--- a/pipe_tools/beam/requirements.py
+++ b/pipe_tools/beam/requirements.py
@@ -1,0 +1,69 @@
+import logging
+import sys
+
+# From https://beam.apache.org/documentation/sdks/python-dependencies/
+beam_requirement_text = """
+avro-python3    >=1.8.1,<2.0.0; python_version >= "3.0"
+avro    >=1.8.1,<2.0.0; python_version < "3.0"
+crcmod  >=1.7,<2.0
+dill    >=0.2.9,<0.2.10
+fastavro    >=0.21.4,<0.22
+future  >=0.16.0,<1.0.0
+futures >=3.2.0,<4.0.0; python_version < "3.0"
+google-apitools >=0.5.26,<0.5.27
+google-cloud-bigquery   >=1.6.0,<1.7.0
+google-cloud-bigtable   ==0.31.1
+google-cloud-core   ==0.28.1
+google-cloud-pubsub ==0.39.0
+googledatastore >=7.0.1,<7.1; python_version < "3.0"
+grpcio  >=1.8,<2
+hdfs    >=2.1.0,<3.0.0
+httplib2    >=0.8,<=0.11.3
+mock    >=1.0.1,<3.0.0
+oauth2client    >=2.0.1,<4
+proto-google-cloud-datastore-v1 >=0.90.0,<=0.90.4
+protobuf    >=3.5.0.post1,<4
+pyarrow >=0.11.1,<0.12.0; python_version >= "3.0" or platform_system != "Windows"
+pydot   >=1.2.0,<1.3
+pytz    >=2018.3
+pyvcf   >=0.6.8,<0.7.0; python_version < "3.0"
+pyyaml  >=3.12,<4.0.0
+typing  >=3.6.0,<3.7.0; python_version < "3.5.0"
+"""
+
+py2_reqs = set([
+    'python_version<"3.0"',
+
+    ])
+
+py3_reqs = set([
+    'python_version>="3.0"',
+    'python_version>="3.0"orplatform_system!="windows"'
+    ])
+
+def parse_beam_requirements(text):
+    py3 = (sys.version_info.major == 3)
+    requirements = []
+    for line in text.split('\n'):
+        line = line.strip()
+        if not line:
+            continue
+        if ';' in line:
+            line, req = line.split(';', 1)
+            req = req.lower().replace(' ', '')
+            if req in py3_reqs:
+                if not py3:
+                    continue
+            elif req in py2_reqs:
+                if py3:
+                    continue
+            elif req == 'python_version<"3.5.0"':
+                if sys.version_info.major == 3 and sys.version_info.minor >= 5:
+                    # Hack for typing module
+                    continue
+            else:
+                logging.warn('ignoring spec: {}'.format(req))
+        requirements.append('{}'.format(line.replace(' ','')))
+    return requirements
+
+requirements = parse_beam_requirements(beam_requirement_text)

--- a/pipe_tools/coders/__init__.py
+++ b/pipe_tools/coders/__init__.py
@@ -1,3 +1,2 @@
 from jsoncoder import JSONDictCoder
 from jsoncoder import JSONDict
-from jsoncoder import ReadAsJSONDict

--- a/pipe_tools/coders/jsoncoder.py
+++ b/pipe_tools/coders/jsoncoder.py
@@ -11,43 +11,10 @@ class JSONDictCoder(beam.coders.Coder):
         return ujson.dumps(value)
 
     def decode(self, value):
-        return JSONDict(ujson.loads(value))
+        return ujson.loads(value)
 
     def is_deterministic(self):
         return True
 
+JSONDict = typehints.Dict[str, typehints.Any]
 
-class JSONDict(dict):
-    """A single AIS/VMS message stored as a python dict with string keys
-    We need to make this a class so taht we can properly use the type coding system
-    in Beam to JSON-encode messages as we move them around.
-    """
-    pass
-
-beam.coders.registry.register_coder(JSONDict, JSONDictCoder)
-
-
-class ReadAsJSONDict(PTransform):
-    """
-    We need this because providing a custom coder to BigQuerySource does not seem to work, and we need the
-    output from that source to be a JSONDict so that our JSONCoder will get used to serialize the rows
-    when we pass data from one node to another in Beam (because json is faster and better then pickle)
-    """
-
-    def __init__(self, source):
-        self.source = source
-
-    def expand(self, p):
-        return (
-            p | beam.io.Read(self.source)
-            | beam.ParDo(JSONDictDoFn())
-        )
-
-
-@typehints.with_input_types(typehints.Dict)
-@typehints.with_output_types(JSONDict)
-class JSONDictDoFn(beam.DoFn):
-    """converts a dict to a JSONDict"""
-
-    def process(self, d):
-        yield JSONDict(d)

--- a/pipe_tools/cookbook/normalize/normalize.py
+++ b/pipe_tools/cookbook/normalize/normalize.py
@@ -17,7 +17,6 @@ from apache_beam.io.gcp.bigquery import BigQueryDisposition
 
 from pipe_tools.utils.timestamp import as_timestamp
 from pipe_tools.io.bigquery import QueryHelper
-from pipe_tools.coders import ReadAsJSONDict
 from pipe_tools.io import WriteToBigQueryDatePartitioned
 from pipe_tools.timestamp import TimestampedValueDoFn
 from pipe_tools.timestamp import ParseBeamBQStrTimestampDoFn
@@ -108,7 +107,7 @@ def run(args=None):
   pipeline = beam.Pipeline(options=pipeline_options)
   (
       pipeline
-      | "ReadSource" >> ReadAsJSONDict(source)
+      | "ReadSource" >> beam.io.Read(source)
       | "ConvertTimestamp" >> beam.ParDo(ParseBeamBQStrTimestampDoFn())
       | "AddTimestamp" >> beam.ParDo(TimestampedValueDoFn())
       | "NormalizeNames" >> beam.ParDo(NormalizeNamesDoFn())

--- a/pipe_tools/cookbook/read_bigquery.py
+++ b/pipe_tools/cookbook/read_bigquery.py
@@ -8,7 +8,6 @@ from apache_beam.options.pipeline_options import StandardOptions, TypeOptions, G
 from pipe_tools.timestamp import TimestampedValueDoFn
 from pipe_tools.io import WriteToDatePartitionedFiles
 from pipe_tools.timestamp import ParseBeamBQStrTimestampDoFn
-from pipe_tools.coders import ReadAsJSONDict
 from pipe_tools.options import ReadFileAction
 
 # Read from Bigquery and write to Date Partitioned Files
@@ -64,7 +63,7 @@ def build_pipeline(options):
     pipeline = beam.Pipeline(options=options)
     (
         pipeline
-        | "ReadFromBigQuery" >> ReadAsJSONDict(source)
+        | "ReadFromBigQuery" >> beam.io.Read(source)
         | "ConvertTimestamp" >> beam.ParDo(ParseBeamBQStrTimestampDoFn())
         | "AddTimestampedValue" >> beam.ParDo(TimestampedValueDoFn())
         | "WriteDatePartitions" >> WriteToDatePartitionedFiles(file_path_prefix=options.output_file_prefix,

--- a/pipe_tools/cookbook/read_write_bigquery.py
+++ b/pipe_tools/cookbook/read_write_bigquery.py
@@ -8,7 +8,6 @@ from apache_beam.options.pipeline_options import StandardOptions, TypeOptions, G
 from pipe_tools.timestamp import TimestampedValueDoFn
 from pipe_tools.io import WriteToBigQueryDatePartitioned
 from pipe_tools.timestamp import ParseBeamBQStrTimestampDoFn
-from pipe_tools.coders import ReadAsJSONDict
 from pipe_tools.options import ReadFileAction
 
 # Read from Bigquery and write to BigQuery Date Partitioned tables
@@ -65,7 +64,7 @@ def build_pipeline(options):
     pipeline = beam.Pipeline(options=options)
     (
         pipeline
-        | "ReadFromBigQuery" >> ReadAsJSONDict(source)
+        | "ReadFromBigQuery" >> beam.io.Read(source)
         | "ConvertTimestamp" >> beam.ParDo(ParseBeamBQStrTimestampDoFn())
         | "AddTimestampedValue" >> beam.ParDo(TimestampedValueDoFn())
         | "WriteDatePartitions" >> WriteToBigQueryDatePartitioned(

--- a/pipe_tools/cookbook/schema_autodetect.py
+++ b/pipe_tools/cookbook/schema_autodetect.py
@@ -15,7 +15,6 @@ from pipe_tools.generator import GenerateMessages
 from pipe_tools.generator import MessageGenerator
 from pipe_tools.io.bigquery import BigQueryWrapper
 from pipe_tools.io.bigquery import decode_table_ref
-from pipe_tools.coders import ReadAsJSONDict
 from pipe_tools.transforms.util import DoNothing
 
 # Bigquery Schema Autodetect

--- a/pipe_tools/generator/generator.py
+++ b/pipe_tools/generator/generator.py
@@ -5,6 +5,7 @@ import apache_beam as beam
 from apache_beam import typehints
 
 from pipe_tools.timestamp import timestampFromDatetime
+from pipe_tools.coders import JSONDict
 
 DEFAULT_START_TS = timestampFromDatetime(datetime(2017, 1, 1, 0, 0, 0, tzinfo=pytz.UTC))
 HOUR_IN_SECONDS = 60 * 60

--- a/pipe_tools/generator/generator.py
+++ b/pipe_tools/generator/generator.py
@@ -5,7 +5,6 @@ import apache_beam as beam
 from apache_beam import typehints
 
 from pipe_tools.timestamp import timestampFromDatetime
-from pipe_tools.coders import JSONDict
 
 DEFAULT_START_TS = timestampFromDatetime(datetime(2017, 1, 1, 0, 0, 0, tzinfo=pytz.UTC))
 HOUR_IN_SECONDS = 60 * 60
@@ -24,7 +23,7 @@ class MessageGenerator():
     def messages(self):
         ts = self.start_ts
         for idx in xrange(self.count):
-            yield JSONDict(mmsi=1, timestamp=ts, idx=idx)
+            yield dict(mmsi=1, timestamp=ts, idx=idx)
             ts += self.increment
 
     def bigquery_schema(self):

--- a/pipe_tools/io/bigquery.py
+++ b/pipe_tools/io/bigquery.py
@@ -8,7 +8,6 @@ from apache_beam.io.gcp.bigquery import WriteToBigQuery
 from apache_beam.io.gcp.bigquery import parse_table_schema_from_json
 import apache_beam.io.gcp.internal.clients.bigquery as bq
 from apache_beam.utils import retry
-from apache_beam.io.gcp.bigquery import _parse_table_reference
 from apache_beam.io.gcp.internal.clients.bigquery import TableSchema
 
 
@@ -72,7 +71,7 @@ def parse_table_schema(schema):
 # into a TableReferenece.   You can supply each component separately,
 # or all in one string
 def decode_table_ref(table, dataset=None, project=None):
-    return _parse_table_reference(table, dataset, project)
+    return beam.io.gcp.bigquery_tools.parse_table_reference(table, dataset, project)
 
 
 # encode a TableReference to a string representation

--- a/pipe_tools/io/bqdatepartitionedsink.py
+++ b/pipe_tools/io/bqdatepartitionedsink.py
@@ -101,7 +101,7 @@ class BigQueryDatePartitionedSink(DatePartitionedFileSink):
             yield (job_id, table_ref, date_ts)
 
 
-    def finalize_write(self, init_result, writer_results):
+    def finalize_write(self, init_result, writer_results, pre_finalize_result):
         # writer_results is LIST[ LIST[ TUPLE[date_ts, gcs_path] ] ]
         # so first we need to flatten it to just LIST[ TUPLE[date_ts, gcs_path] ]
         shard_paths = it.chain.from_iterable(writer_results)

--- a/pipe_tools/io/datepartitionedsink.py
+++ b/pipe_tools/io/datepartitionedsink.py
@@ -14,7 +14,6 @@ from apache_beam.io.filesystem import CompressionTypes
 from pipe_tools.timestamp import SECONDS_IN_DAY
 from pipe_tools.timestamp import datetimeFromTimestamp
 from pipe_tools.coders import JSONDictCoder
-from pipe_tools.coders import JSONDict
 from apache_beam import typehints
 from apache_beam.typehints import Tuple, KV
 
@@ -77,7 +76,7 @@ class DateShardDoFn(beam.DoFn):
         self.shard_counter += 1
         if self.shard_counter >= self.shards_per_day:
             self.shard_counter -= self.shards_per_day
-        assert isinstance(element, JSONDict), 'element must be a JSONDict'
+        assert isinstance(element, dict), 'element must be a dict'
         yield ((date, shard), element)
 
 

--- a/pipe_tools/io/gcp/gcpsink.py
+++ b/pipe_tools/io/gcp/gcpsink.py
@@ -3,8 +3,7 @@ import apache_beam as beam
 from apache_beam.io.gcp.bigquery import BigQueryDisposition
 
 from pipe_tools.coders import JSONDictCoder
-from pipe_tools.coders import ReadAsJSONDict
-from pipe_tools.timestamp import ParseBeamBQStrTimestampDoFn
+=from pipe_tools.timestamp import ParseBeamBQStrTimestampDoFn
 from pipe_tools.io.bigquery import QueryHelper
 from pipe_tools.io import WriteToBigQueryDatePartitioned
 

--- a/pipe_tools/io/gcp/gcpsink.py
+++ b/pipe_tools/io/gcp/gcpsink.py
@@ -3,7 +3,7 @@ import apache_beam as beam
 from apache_beam.io.gcp.bigquery import BigQueryDisposition
 
 from pipe_tools.coders import JSONDictCoder
-=from pipe_tools.timestamp import ParseBeamBQStrTimestampDoFn
+from pipe_tools.timestamp import ParseBeamBQStrTimestampDoFn
 from pipe_tools.io.bigquery import QueryHelper
 from pipe_tools.io import WriteToBigQueryDatePartitioned
 

--- a/pipe_tools/io/gcp/gcpsource.py
+++ b/pipe_tools/io/gcp/gcpsource.py
@@ -3,7 +3,7 @@ import logging
 import apache_beam as beam
 
 from pipe_tools.coders import JSONDictCoder
-=from pipe_tools.timestamp import ParseBeamBQStrTimestampDoFn
+from pipe_tools.timestamp import ParseBeamBQStrTimestampDoFn
 from pipe_tools.io.bigquery import QueryHelper
 from pipe_tools.io.gcp import parse_gcp_path
 

--- a/pipe_tools/io/gcp/gcpsource.py
+++ b/pipe_tools/io/gcp/gcpsource.py
@@ -3,8 +3,7 @@ import logging
 import apache_beam as beam
 
 from pipe_tools.coders import JSONDictCoder
-from pipe_tools.coders import ReadAsJSONDict
-from pipe_tools.timestamp import ParseBeamBQStrTimestampDoFn
+=from pipe_tools.timestamp import ParseBeamBQStrTimestampDoFn
 from pipe_tools.io.bigquery import QueryHelper
 from pipe_tools.io.gcp import parse_gcp_path
 
@@ -41,7 +40,7 @@ class GCPSource(beam.PTransform):
         source = beam.io.gcp.bigquery.BigQuerySource(query=self.query)
         return (
             pcoll
-            | "ReadFromBigQuery" >> ReadAsJSONDict(source)
+            | "ReadFromBigQuery" >> beam.io.Read(source)
             | "ConvertTimestamp" >> beam.ParDo(ParseBeamBQStrTimestampDoFn(fields=list(ts_fields)))
         )
 

--- a/pipe_tools/io/keypartitionedsink.py
+++ b/pipe_tools/io/keypartitionedsink.py
@@ -12,7 +12,6 @@ from apache_beam.transforms import window
 from apache_beam.io.filesystem import CompressionTypes
 
 from pipe_tools.coders import JSONDictCoder
-from pipe_tools.coders import JSONDict
 
 from apache_beam import typehints
 from apache_beam.typehints import Tuple, KV
@@ -76,7 +75,7 @@ class KeyShardDoFn(beam.DoFn):
         self.shard_counter += 1
         if self.shard_counter >= self.shards_per_key:
             self.shard_counter -= self.shards_per_key
-        assert isinstance(element, JSONDict), 'element must be a JSONDict'
+        assert isinstance(element, dict), 'element must be a dict'
         yield ((element_key, shard), element)
 
 

--- a/pipe_tools/io/partitionedsink.py
+++ b/pipe_tools/io/partitionedsink.py
@@ -29,7 +29,6 @@ from apache_beam.typehints import Tuple, KV
 T = typehints.TypeVariable('T')
 
 
-@typehints.with_input_types(JSONDict)
 @typehints.with_output_types(str)
 class WritePartitionedFiles(PTransform):
     """
@@ -212,7 +211,7 @@ class PartitionedFileSink(FileBasedSink):
                     logging.debug('Rename successful: %s -> %s', src, dest)
             return exceptions
 
-    def finalize_write(self, init_result, writer_results):
+    def finalize_write(self, init_result, writer_results, pre_finalize_result):
         file_path_prefix = self.file_path_prefix.get()
 
         shard_paths = it.chain.from_iterable(writer_results)

--- a/pipe_tools/timestamp.py
+++ b/pipe_tools/timestamp.py
@@ -196,7 +196,7 @@ class SafeParseBeamBQStrTimestampDoFn(beam.DoFn):
         super(SafeParseBeamBQStrTimestampDoFn, self).__init__()
 
     def process(self, element):
-        new_element = JSONDict(element)
+        new_element = element.copy()
         for f in self.fields:
             v = new_element.get(f)
             if v is not None:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import sys
 
 from setuptools import find_packages
 from setuptools import setup
-
+from pipe_tools.beam.requirements import requirements as DATAFLOW_PINNED_DEPENDENCIES
 
 DEPENDENCIES = [
     "newlinejson",
@@ -21,73 +21,6 @@ DEPENDENCIES = [
     "udatetime",
     "ujson"
 ]
-
-# From https://beam.apache.org/documentation/sdks/python-dependencies/
-beam_requirement_text = """
-avro-python3    >=1.8.1,<2.0.0; python_version >= "3.0"
-avro    >=1.8.1,<2.0.0; python_version < "3.0"
-crcmod  >=1.7,<2.0
-dill    >=0.2.9,<0.2.10
-fastavro    >=0.21.4,<0.22
-future  >=0.16.0,<1.0.0
-futures >=3.2.0,<4.0.0; python_version < "3.0"
-google-apitools >=0.5.26,<0.5.27
-google-cloud-bigquery   >=1.6.0,<1.7.0
-google-cloud-bigtable   ==0.31.1
-google-cloud-core   ==0.28.1
-google-cloud-pubsub ==0.39.0
-googledatastore >=7.0.1,<7.1; python_version < "3.0"
-grpcio  >=1.8,<2
-hdfs    >=2.1.0,<3.0.0
-httplib2    >=0.8,<=0.11.3
-mock    >=1.0.1,<3.0.0
-oauth2client    >=2.0.1,<4
-proto-google-cloud-datastore-v1 >=0.90.0,<=0.90.4
-protobuf    >=3.5.0.post1,<4
-pyarrow >=0.11.1,<0.12.0; python_version >= "3.0" or platform_system != "Windows"
-pydot   >=1.2.0,<1.3
-pytz    >=2018.3
-pyvcf   >=0.6.8,<0.7.0; python_version < "3.0"
-pyyaml  >=3.12,<4.0.0
-typing  >=3.6.0,<3.7.0; python_version < "3.5.0"
-"""
-
-py2_reqs = set([
-    'python_version<"3.0"',
-
-    ])
-
-py3_reqs = set([
-    'python_version>="3.0"',
-    'python_version>="3.0"orplatform_system!="windows"'
-    ])
-
-def parse_beam_requirements(text):
-    py3 = (sys.version_info.major == 3)
-    requirements = []
-    for line in text.split('\n'):
-        line = line.strip()
-        if not line:
-            continue
-        if ';' in line:
-            line, req = line.split(';', 1)
-            req = req.lower().replace(' ', '')
-            if req in py3_reqs:
-                if not py3:
-                    continue
-            elif req in py2_reqs:
-                if py3:
-                    continue
-            elif req == 'python_version<"3.5.0"':
-                if sys.version_info.major == 3 and sys.version_info.minor >= 5:
-                    # Hack for typing module
-                    continue
-            else:
-                logging.warn('ignoring spec: {}'.format(req))
-        requirements.append('{}'.format(line.replace(' ','')))
-    return requirements
-
-DATAFLOW_PINNED_DEPENDENCIES = parse_beam_requirements(beam_requirement_text)
 
 SCRIPTS = [
     'bin/pipe-tools-utils',

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ Setup script for pipe-tools
 
 import codecs
 import os
+import sys
 
 from setuptools import find_packages
 from setuptools import setup
@@ -21,48 +22,72 @@ DEPENDENCIES = [
     "ujson"
 ]
 
-# Frozen dependencies for the google cloud dataflow dependency
-DATAFLOW_PINNED_DEPENDENCIES = [
-    "PyYAML==3.12",
-    "apache-beam==2.1.0",
-    "avro==1.8.2",
-    "cachetools==2.0.1",
-    "certifi==2017.7.27.1",
-    "chardet==3.0.4",
-    "crcmod==1.7",
-    "dill==0.2.6",
-    "enum34==1.1.6",
-    "future==0.16.0",
-    "futures==3.1.1",
-    "gapic-google-cloud-pubsub-v1==0.15.4",
-    "google-apitools==0.5.11",
-    "google-auth-httplib2==0.0.2",
-    "google-auth==1.1.0",
-    "google-cloud-bigquery==0.25.0",
-    "google-cloud-core==0.25.0",
-    "google-cloud-dataflow==2.1.0",
-    "google-cloud-pubsub==0.26.0",
-    "google-gax==0.15.15",
-    "googleapis-common-protos==1.5.2",
-    "googledatastore==7.0.1",
-    "grpc-google-iam-v1==0.11.3",
-    "grpcio==1.4.0",
-    "httplib2==0.9.2",
-    "idna==2.6",
-    "mock==2.0.0",
-    "oauth2client==3.0.0",
-    "pbr==3.1.1",
-    "ply==3.8",
-    "proto-google-cloud-datastore-v1==0.90.4",
-    "proto-google-cloud-pubsub-v1==0.15.4",
-    "protobuf==3.3.0",
-    "pyasn1-modules==0.1.4",
-    "pyasn1==0.3.5",
-    "requests==2.18.4",
-    "rsa==3.4.2",
-    "six==1.10.0",
-    "urllib3==1.22"
-]
+# From https://beam.apache.org/documentation/sdks/python-dependencies/
+beam_requirement_text = """
+avro-python3    >=1.8.1,<2.0.0; python_version >= "3.0"
+avro    >=1.8.1,<2.0.0; python_version < "3.0"
+crcmod  >=1.7,<2.0
+dill    >=0.2.9,<0.2.10
+fastavro    >=0.21.4,<0.22
+future  >=0.16.0,<1.0.0
+futures >=3.2.0,<4.0.0; python_version < "3.0"
+google-apitools >=0.5.26,<0.5.27
+google-cloud-bigquery   >=1.6.0,<1.7.0
+google-cloud-bigtable   ==0.31.1
+google-cloud-core   ==0.28.1
+google-cloud-pubsub ==0.39.0
+googledatastore >=7.0.1,<7.1; python_version < "3.0"
+grpcio  >=1.8,<2
+hdfs    >=2.1.0,<3.0.0
+httplib2    >=0.8,<=0.11.3
+mock    >=1.0.1,<3.0.0
+oauth2client    >=2.0.1,<4
+proto-google-cloud-datastore-v1 >=0.90.0,<=0.90.4
+protobuf    >=3.5.0.post1,<4
+pyarrow >=0.11.1,<0.12.0; python_version >= "3.0" or platform_system != "Windows"
+pydot   >=1.2.0,<1.3
+pytz    >=2018.3
+pyvcf   >=0.6.8,<0.7.0; python_version < "3.0"
+pyyaml  >=3.12,<4.0.0
+typing  >=3.6.0,<3.7.0; python_version < "3.5.0"
+"""
+
+py2_reqs = set([
+    'python_version<"3.0"',
+
+    ])
+
+py3_reqs = set([
+    'python_version>="3.0"',
+    'python_version>="3.0"orplatform_system!="windows"'
+    ])
+
+def parse_beam_requirements(text):
+    py3 = (sys.version_info.major == 3)
+    requirements = []
+    for line in text.split('\n'):
+        line = line.strip()
+        if not line:
+            continue
+        if ';' in line:
+            line, req = line.split(';', 1)
+            req = req.lower().replace(' ', '')
+            if req in py3_reqs:
+                if not py3:
+                    continue
+            elif req in py2_reqs:
+                if py3:
+                    continue
+            elif req == 'python_version<"3.5.0"':
+                if sys.version_info.major == 3 and sys.version_info.minor >= 5:
+                    # Hack for typing module
+                    continue
+            else:
+                logging.warn('ignoring spec: {}'.format(req))
+        requirements.append('{}'.format(line.replace(' ','')))
+    return requirements
+
+DATAFLOW_PINNED_DEPENDENCIES = parse_beam_requirements(beam_requirement_text)
 
 SCRIPTS = [
     'bin/pipe-tools-utils',

--- a/tests/test_coders.py
+++ b/tests/test_coders.py
@@ -38,8 +38,8 @@ class TestCoders():
         messages = MessageGenerator()
 
         source = beam.Create(messages)
-        assert source.get_output_type() == JSONDict
-        assert typecoders.registry._coders.get(source.get_output_type()) == JSONDictCoder
+        assert source.get_output_type() == Dict[str, Union[float, int]], 
+                                                (source.get_output_type(), JSONDict)
 
         with _TestPipeline() as p:
             result = (

--- a/tests/test_coders.py
+++ b/tests/test_coders.py
@@ -6,6 +6,7 @@ from apache_beam.testing.test_pipeline import TestPipeline as _TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 from apache_beam.coders import typecoders
+from apache_beam.typehints import Dict, Union
 
 from pipe_tools.coders import JSONDictCoder
 from pipe_tools.coders import JSONDict

--- a/tests/test_coders.py
+++ b/tests/test_coders.py
@@ -38,8 +38,7 @@ class TestCoders():
         messages = MessageGenerator()
 
         source = beam.Create(messages)
-        assert source.get_output_type() == Dict[str, Union[float, int]], 
-                                                (source.get_output_type(), JSONDict)
+        assert source.get_output_type() == Dict[str, Union[float, int]], (source.get_output_type(), JSONDict)
 
         with _TestPipeline() as p:
             result = (

--- a/tests/test_datepartitionedsink.py
+++ b/tests/test_datepartitionedsink.py
@@ -25,7 +25,7 @@ class TestDatePartitionedSink():
         count = 24 * 3  # 3 days
         ts = start_ts
         for t in xrange(count):
-            yield JSONDict(mmsi=1, timestamp= ts)
+            yield dict(mmsi=1, timestamp= ts)
             ts += increment
 
     @pytest.mark.parametrize("shards_per_day", [1,2,3])

--- a/tests/test_keypartitionedsink.py
+++ b/tests/test_keypartitionedsink.py
@@ -21,7 +21,7 @@ class TestKeyPartitionedSink():
         for vessel_id in xrange(count):
             if stringify:
                 vessel_id = str(vessel_id)
-            yield JSONDict(**{key: vessel_id})
+            yield dict(**{key: vessel_id})
 
     @pytest.mark.parametrize("stringify,key,count,shard_name_template", [
         (False, 'id', 100, None),


### PR DESCRIPTION
1. Change pinned dependencies to correspond to Beam 2.11
    - `pipe_tools/beam/requirements.py` has code to parse the pinned requirements from the
        text on the Beam requirements page at
        https://beam.apache.org/documentation/sdks/python-dependencies/
2. Fix use of `JsonDict`.   `JsonDict` is now only used as a type hint. The way typehints was
   handled got changed in Beam 2.4, so now typehint can not also be a dictionary. Since it's not
    a real dictionary subclass, it can no longer be used as a constructor. So, places where it was
    used as constructor have been converted to use dict instead. There are a few other, similar,
    changes.

Notes: 
   * Code that uses `pipe-tools` 3 will need to be adapted as in 2. 
   * Setup files in code that uses `pipe-tools` can import `pipe_tools.beam.requirements` 
      and grab the pinned requirements from there rather than duplicating them.
   * `BigQueryWrapper` from `apache_beam.io.gcp.bigquery` was deprecated and could no
       longer be subclassed. So now I grab the wrapper from `apache_beam.io.gcp.biqquery_tools`
       which has some small interface changes. Be on the lookout for issues related to this.
   * The code used to pull MAX_RETRIES from inside dataflow, but that value disappeared, so
      I set it to `8`, rather arbitrarily.