### PR TITLE
add testing function that includes tolerance in fp compare

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,23 @@
 language: python
 
+sudo: required
+
+services:
+  - docker
+
 cache:
   directories:
   - ~/.cache/pip
 
 python:
-- 2.7
 - 3.7
 
 install:
-- pip install -e .
+- docker-compose build
 
 script:
-- py.test tests
+- docker-compose --version
+- docker-compose run test
 
 notifications:
   slack:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,13 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## 3.1.3 - (2020-11-04)
+
+### Added
+
+  * [Data Pipeline/PIPELINE-229](https://globalfishingwatch.atlassian.net/browse/PIPELINE-229): Adds
+    * Predicate for apache_beam.testing.util.assert_that with floating tolerance.
+
 ## 3.1.2 - (2020-06-11)
 
 ### Added

--- a/pipe_tools/__init__.py
+++ b/pipe_tools/__init__.py
@@ -3,7 +3,7 @@ Tools for running the GFW pipeline.
 """
 
 
-__version__ = '3.1.2'
+__version__ = '3.1.3'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-tools'

--- a/pipe_tools/utils/__init__.py
+++ b/pipe_tools/utils/__init__.py
@@ -1,2 +1,3 @@
 from .flatten import flatten
 from .uuid import GFW_UUID
+from .test import approx_equal_to

--- a/pipe_tools/utils/test.py
+++ b/pipe_tools/utils/test.py
@@ -1,0 +1,63 @@
+from apache_beam.testing.util import BeamAssertException
+import warnings
+import math
+
+def _approx_equal(expected, actual, fp_abs_tol, fp_rel_tol):
+    try:
+        if isinstance(expected, (list, tuple)):
+            return (len(actual) == len(expected) and 
+                    all(_approx_equal(a, b, fp_abs_tol, fp_rel_tol) for (a, b) in zip(expected, actual)))
+        if isinstance(expected, dict):
+            return (sorted(actual.keys()) == sorted(expected.keys()) and
+                    all(_approx_equal(expected[k], actual[k], fp_abs_tol, fp_rel_tol) for k in expected))
+        if isinstance(expected, float) or isinstance(actual, float):
+            return ((math.isinf(actual) and math.isinf(expected)) or
+                    (math.isnan(actual) and math.isnan(expected)) or
+                    abs(actual - expected) <= max(fp_abs_tol,
+                            0.5 * fp_rel_tol * (abs(actual) + abs(expected)))) 
+    except:
+        warnings.warn('comparison failure in approx_equal_to')
+        return False
+    return actual == expected
+
+
+# Once we have updated to recent version of Beam, we could simplify this 
+# by using Beam's `equal_to` with a custom `equal_fn`
+
+def approx_equal_to(expected, fp_abs_tol=1e-8, fp_rel_tol=1e-5):
+    """Predicate for apache_beam.testing.util.assert_that with floating tolerance
+
+    Parameters
+    ----------
+    expected : obj
+        The expected result that we are comparing too
+    fp_abs_tol : float
+        Absolute tolerance for comparing floating point numbers
+    fp_abs_rel : float
+        Relative tolerance for comparing floating point numbers
+
+    Returns
+    -------
+    function(actual) -> None
+        Raises BeamAssertException if actual is not approximately equal to expected.
+    """
+    def _check(actual):
+        expected_list = list(expected)
+        unexpected = []
+        for element in actual:
+          found = False
+          for i, v in enumerate(expected_list):
+            if _approx_equal(v, element, fp_abs_tol, fp_rel_tol):
+              found = True
+              expected_list.pop(i)
+              break
+          if not found:
+            unexpected.append(element)
+        if unexpected or expected_list:
+          msg = 'Failed assert: %r == %r' % (expected, actual)
+          if unexpected:
+            msg = msg + ', unexpected elements %r' % unexpected
+          if expected_list:
+            msg = msg + ', missing elements %r' % expected_list
+          raise BeamAssertException(msg)
+    return _check


### PR DESCRIPTION
The built in equality testing for Apache Beam compares floating point values exactly. However,
sometimes these result shift slightly due to implementation changes in numpy, serialization
changes in python or Beam, etc. This break all the tests, so this utility function is a way to avoid that.

`util.test.approx_equal_to` should be a more or less drop in replacement for from `apache_beam.testing.util.equal_to`
