### PR TITLE
Changes to support datetime values when reading and writing in the segment step

### DIFF
--- a/pipe_tools/coders/jsoncoder.py
+++ b/pipe_tools/coders/jsoncoder.py
@@ -1,18 +1,45 @@
 import ujson
 import apache_beam as beam
 import six
+import datetime
+import pytz
+import copy
 from apache_beam import typehints
 from apache_beam import PTransform
 
 
+epoch = datetime.datetime.utcfromtimestamp(0).replace(tzinfo=pytz.utc)
+
+def _datetime_to_s(x):
+    return (x - epoch).total_seconds()
+
+def _s_to_datetime(x):
+    return epoch + datetime.timedelta(seconds=x)
+
 class JSONDictCoder(beam.coders.Coder):
     """A coder used for reading and writing json"""
 
+    def __init__(self, time_fields = []):
+        self.time_fields = time_fields
+
+    def _encode(self, value):
+        replacements = {x: _datetime_to_s(value.get(x)) for x in self.time_fields}
+        new_value = copy.deepcopy(value)
+        new_value.update(replacements)
+        print(replacements, value, new_value)
+        return new_value
+
     def encode(self, value):
-        return six.ensure_binary(ujson.dumps(value))
+        return six.ensure_binary(ujson.dumps(self._encode(value)))
+
+    def _decode(self, value):
+        replacements = {x: _s_to_datetime(value.get(x)) for x in self.time_fields}
+        new_value = copy.deepcopy(value)
+        new_value.update(replacements)
+        return new_value
 
     def decode(self, value):
-        return ujson.loads(six.ensure_str(value))
+        return self._decode(ujson.loads(six.ensure_str(value)))
 
     def is_deterministic(self):
         return True

--- a/pipe_tools/coders/jsoncoder.py
+++ b/pipe_tools/coders/jsoncoder.py
@@ -23,17 +23,16 @@ class JSONDictCoder(beam.coders.Coder):
         self.time_fields = time_fields
 
     def _encode(self, value):
-        replacements = {x: _datetime_to_s(value.get(x)) for x in self.time_fields}
+        replacements = {x: _datetime_to_s(value.get(x)) for x in self.time_fields if x in value.keys()}
         new_value = copy.deepcopy(value)
         new_value.update(replacements)
-        print(replacements, value, new_value)
         return new_value
 
     def encode(self, value):
         return six.ensure_binary(ujson.dumps(self._encode(value)))
 
     def _decode(self, value):
-        replacements = {x: _s_to_datetime(value.get(x)) for x in self.time_fields}
+        replacements = {x: _s_to_datetime(value.get(x)) for x in self.time_fields if x in value.keys()}
         new_value = copy.deepcopy(value)
         new_value.update(replacements)
         return new_value

--- a/pipe_tools/coders/jsoncoder.py
+++ b/pipe_tools/coders/jsoncoder.py
@@ -11,7 +11,7 @@ from apache_beam import PTransform
 epoch = datetime.datetime.utcfromtimestamp(0).replace(tzinfo=pytz.utc)
 
 def _datetime_to_s(x):
-    return (x - epoch).total_seconds()
+    return ((x - epoch).total_seconds()) if isinstance(x, datetime.datetime) else x
 
 def _s_to_datetime(x):
     return epoch + datetime.timedelta(seconds=x)

--- a/pipe_tools/io/datepartitionedsink.py
+++ b/pipe_tools/io/datepartitionedsink.py
@@ -35,7 +35,7 @@ class WriteToDatePartitionedFiles(WritePartitionedFiles):
                  append_trailing_newlines=True,
                  shards_per_day=None,
                  shard_name_template=None,
-                 coder=JSONDictCoder(time_fields=['timestamp']),
+                 coder=JSONDictCoder(),
                  compression_type=CompressionTypes.AUTO,
                  header=None):
 

--- a/pipe_tools/io/datepartitionedsink.py
+++ b/pipe_tools/io/datepartitionedsink.py
@@ -35,7 +35,7 @@ class WriteToDatePartitionedFiles(WritePartitionedFiles):
                  append_trailing_newlines=True,
                  shards_per_day=None,
                  shard_name_template=None,
-                 coder=JSONDictCoder(),
+                 coder=JSONDictCoder(time_fields=['timestamp']),
                  compression_type=CompressionTypes.AUTO,
                  header=None):
 

--- a/pipe_tools/io/datepartitionedsink.py
+++ b/pipe_tools/io/datepartitionedsink.py
@@ -35,7 +35,7 @@ class WriteToDatePartitionedFiles(WritePartitionedFiles):
                  append_trailing_newlines=True,
                  shards_per_day=None,
                  shard_name_template=None,
-                 coder=JSONDictCoder(),
+                 coder=JSONDictCoder(time_fields=['timestamp','first_msg_timestamp','last_msg_timestamp','first_msg_of_day_timestamp','last_msg_of_day_timestamp','origin_ts','last_pos_ts','timestamp_min','timestamp_max','timestamp_first','timestamp_last']),
                  compression_type=CompressionTypes.AUTO,
                  header=None):
 

--- a/pipe_tools/io/partitionedsink.py
+++ b/pipe_tools/io/partitionedsink.py
@@ -64,7 +64,7 @@ class PartitionedFileSink(FileBasedSink):
                  file_name_suffix='',
                  append_trailing_newlines=True,
                  shard_name_template=None,
-                 coder=JSONDictCoder(time_fields=['timestamp']),
+                 coder=JSONDictCoder(time_fields=['timestamp','first_msg_timestamp','last_msg_timestamp','first_msg_of_day_timestamp','last_msg_of_day_timestamp','origin_ts','last_pos_ts','timestamp_min','timestamp_max','timestamp_first','timestamp_last']),
                  compression_type=CompressionTypes.AUTO,
                  header=None):
         self._do_sharding = (shard_name_template != '')

--- a/pipe_tools/io/partitionedsink.py
+++ b/pipe_tools/io/partitionedsink.py
@@ -64,7 +64,7 @@ class PartitionedFileSink(FileBasedSink):
                  file_name_suffix='',
                  append_trailing_newlines=True,
                  shard_name_template=None,
-                 coder=JSONDictCoder(),
+                 coder=JSONDictCoder(time_fields=['timestamp']),
                  compression_type=CompressionTypes.AUTO,
                  header=None):
         self._do_sharding = (shard_name_template != '')

--- a/pipe_tools/timestamp.py
+++ b/pipe_tools/timestamp.py
@@ -100,7 +100,7 @@ def beambqstrFromDatetime(dt):
 
 def rfc3339strFromBeamBQStr(s):
     """Convert a string formatted BEAM_BQ_TIMESTAMP_FORMAT to RFC3339_TIMESTAMP_FORMAT"""
-    return s[:-4].replace(' ', 'T')+'+00:00'
+    return s.strftime('%Y-%m-%dT%H:%M:%S+00:00')
 
 
 def udatetimeFromTimestamp(ts):

--- a/pipe_tools/timestamp.py
+++ b/pipe_tools/timestamp.py
@@ -100,7 +100,7 @@ def beambqstrFromDatetime(dt):
 
 def rfc3339strFromBeamBQStr(s):
     """Convert a string formatted BEAM_BQ_TIMESTAMP_FORMAT to RFC3339_TIMESTAMP_FORMAT"""
-    return s.strftime('%Y-%m-%dT%H:%M:%S+00:00')
+    return s.strftime('%Y-%m-%dT%H:%M:%S+00:00') if isinstance(s,datetime) else s[:-4].replace(' ', 'T')+'+00:00'
 
 
 def udatetimeFromTimestamp(ts):

--- a/tests/test_coders.py
+++ b/tests/test_coders.py
@@ -1,6 +1,7 @@
 import pytest
 import six
 import ujson
+import datetime
 
 import apache_beam as beam
 from apache_beam.testing.test_pipeline import TestPipeline as _TestPipeline
@@ -31,6 +32,14 @@ class TestCoders():
             {"test":None},
         ]
         coder = JSONDictCoder()
+        for r in records:
+            assert r == coder.decode(coder.encode(r))
+
+    def test_JSONDictCoderWithTimeFields(self):
+        records = [
+            {"timestamp": datetime.datetime(2012, 1, 1, 21, 20, 12, tzinfo=datetime.timezone.utc)},
+        ]
+        coder = JSONDictCoder(time_fields=['timestamp'])
         for r in records:
             assert r == coder.decode(coder.encode(r))
 


### PR DESCRIPTION
- When converting a string formatted BEAM_BQ_TIMESTAMP_FORMAT to RFC3339_TIMESTAMP_FORMAT expected to be a string but it comes a `datetime.datetime`. Make support both. (`pipe_tools/timestamp.py:103`)
```
  File "apache_beam/runners/common.py", line 1334, in apache_beam.runners.common._OutputProcessor.process_outputs
  File "/usr/local/lib/python3.7/site-packages/pipe_tools/timestamp.py", line 166, in process
    element[f] = timestampFromBeamBQStr(v)
  File "/usr/local/lib/python3.7/site-packages/pipe_tools/timestamp.py", line 123, in timestampFromBeamBQStr
    return timestampFromDatetime(udatetimeFromBeamBQStr(s))
  File "/usr/local/lib/python3.7/site-packages/pipe_tools/timestamp.py", line 118, in udatetimeFromBeamBQStr
    return udatetime.from_string(rfc3339strFromBeamBQStr(s))
  File "/usr/local/lib/python3.7/site-packages/pipe_tools/timestamp.py", line 103, in rfc3339strFromBeamBQStr
    return s[:-4].replace(' ', 'T')+'+00:00'
TypeError: 'datetime.datetime' object is not subscriptable [while running 'Source0/ConvertTimestamp-ptransform-80']
```
- JSONDictCoder uses `ujson` that does not support to encode the `datetime.datetime`, this type was tackled manually using time_fields to recognize where do the encode and later where to do the decode.
Error related:
```
  File "/usr/local/lib/python3.7/site-packages/pipe_tools/coders/jsoncoder.py", line 12, in encode
    return six.ensure_binary(ujson.dumps(value))
TypeError: datetime.datetime(2012, 1, 1, 21, 20, 12, tzinfo=<UTC>) is not JSON serializable [while running 'WriteOldSegments/WriteToBigquery/Write/WriteImpl/WriteBundles-ptransform-50']
```
- `WriteToDatePartitionedFiles` and `PartitionedFileSink` uses the JSONDictCoder in coder, checked that this is only used in segment step and adjust to the TIMESTAMP fields that are required for writing the output tables (`segments_`, ``legacy_segment_v1_` and `messages_segmented_`)
Fields with TIMESTAMP per table:
```
segments_
-timestamp
-first_msg_timestamp
-last_msg_timestamp
-first_msg_of_day_timestamp
-last_msg_of_day_timestamp

legacy_segment_v1
-timestamp
-origin_ts
-last_pos_ts
-timestamp_min
-timestamp_max
-timestamp_first
-timestamp_last

messages_segmented
-timestamp
```
NOTE: The inclusion of all the time fields in the write (`pipe_tools/io/partitionedsink.py:67`) was made knowing that there are fields that some tables does not contain all fields, but they are checked if those fields exists in jsoncoder (`pipe_tools/coders/jsoncoder.py:26`)

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-807